### PR TITLE
Send ids instead of locs in PrimitiveCList deletes

### DIFF
--- a/client/src/crdt/list/dense_local_list.ts
+++ b/client/src/crdt/list/dense_local_list.ts
@@ -58,7 +58,7 @@ export interface DenseLocalList<L, T> extends ElementSerializer<L> {
     message: Uint8Array,
     timestamp: CausalTimestamp,
     values: ArrayLike<T>
-  ): number;
+  ): [index: number, locs: L[]];
 
   /**
    * Create and return count new locs, inserted starting
@@ -119,7 +119,7 @@ export interface DenseLocalList<L, T> extends ElementSerializer<L> {
     startLoc: L,
     endLoc: L,
     timestamp: CausalTimestamp,
-    ondelete: (startIndex: number, count: number, deletedValues: T[]) => void
+    ondelete: (startIndex: number, deletedLocs: L[], deletedValues: T[]) => void
   ): void;
 
   get(index: number): T;
@@ -139,6 +139,19 @@ export interface DenseLocalList<L, T> extends ElementSerializer<L> {
    * @return [description]
    */
   valuesArray(): T[];
+
+  /**
+   * uniqueNumber must be an int.  Ideally nonnegative
+   * (and then change PrimitiveList's protobuf encoding
+   * from sint to uint),
+   * but for now we don't require this because
+   * Treedoc can give negative values.
+   *
+   * Must work on (just) deleted locs.
+   * @param  loc [description]
+   * @return     [description]
+   */
+  idOf(loc: L): [sender: string, uniqueNumber: number];
 
   canGc(): boolean;
 

--- a/client/src/crdt/list/primitive_list.proto
+++ b/client/src/crdt/list/primitive_list.proto
@@ -12,14 +12,20 @@ message PrimitiveCListInsertMessage {
 }
 
 message PrimitiveCListDeleteMessage {
+  required string sender = 1;
+  required sint32 uniqueNumber = 2;
+}
+
+message PrimitiveCListDeleteRangeMessage {
   required bytes startLoc = 1;
-  optional bytes endLoc = 2;
+  required bytes endLoc = 2;
 }
 
 message PrimitiveCListMessage {
   oneof op {
     PrimitiveCListInsertMessage insert = 1;
     PrimitiveCListDeleteMessage delete = 2;
+    PrimitiveCListDeleteRangeMessage deleteRange = 3;
   }
 }
 


### PR DESCRIPTION
10 percent network savings in automerge_perf TextCrdt benchmark, at the cost of increased memory usage, and possibly slightly higher time / save time / load time (although appears more minor than the memory cost).